### PR TITLE
Fix: Corrected invalid JSX in Hero component

### DIFF
--- a/src/components/ui/hero.tsx
+++ b/src/components/ui/hero.tsx
@@ -132,7 +132,6 @@ const Hero = React.forwardRef<HTMLElement, HeroProps>(
           <source src="https://wp3qshs4sh.ufs.sh/f/CK4jwRqb6gnIJGa1JV6nyWwI6E1z9hlBqTMUe0ivJ2VDjYRm" type="video/mp4" />
           <source src="https://wp3qshs4sh.ufs.sh/f/CK4jwRqb6gnIS4WqeJsgceLjEbMP3uC9rQKsqUFdVNpw05vf" type="video/mp4" />
           {/* Fallback for browsers that don't support the video format */}
-          <div className="absolute inset-0 bg-gradient-to-br from-gray-900 via-black to-gray-800" />
         </video>
 
         {/* Manual play button for when autoplay fails */}


### PR DESCRIPTION
The Hero component contained a self-closing `div` tag within a `video` element, which is not valid JSX. This caused the build to fail. This commit removes the invalid tag, allowing the project to build successfully.